### PR TITLE
Fix incompatible method definition

### DIFF
--- a/src/Testing/SlackFake.php
+++ b/src/Testing/SlackFake.php
@@ -62,7 +62,7 @@ class SlackFake extends Slack
         }, $count, true);
     }
 
-    protected function notify(SlackMessage $slackMessage)
+    public function notify(SlackMessage $slackMessage)
     {
         $this->sent[] = $slackMessage;
     }


### PR DESCRIPTION
Method declarations are not compatible between parent and child classes